### PR TITLE
Gx2 2423 ✅ open ai chat gpt api create chat completion response

### DIFF
--- a/.github/workflows/CI-suite.yml
+++ b/.github/workflows/CI-suite.yml
@@ -81,7 +81,7 @@ jobs:
                   password: ${{secrets.XRAY_CLIENT_SECRET}}
                   testFormat: 'junit' #OPCIONES PARA CAMBIAR: 'junit' (para xml) o 'cucumber' (para json)
                   testPaths: 'reports/test-results.xml' #OPCIONES: '/test-results.xml' o 'cucumber-report.json'
-                  testExecKey: 'GX2-2141' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
+                  testExecKey: 'GX2-2425' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
                   projectKey: 'GX2' #EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
                   testEnvironments: 'Chrome' #ELEGIR EL AMBIENTE DE PRUEBAS (Igual al TX).
 

--- a/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
+++ b/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
@@ -1,18 +1,17 @@
 describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 	let contentType;
 	let authorization;
-	let model;
+	//let model;
 	let messages;
 	beforeEach('Precondition', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			contentType = the.headers.ContentType;
 			authorization = the.headers.Authorization;
-			model = the.model;
+			//model = the.model;
 			messages = the.messages;
 		});
 	});
-
-	it('Validate create a chat completed by API', () => {
+	it('2424 | Validate create a chat completed by API', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
 				method: 'POST',
@@ -22,17 +21,15 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 					Authorization: authorization,
 				},
 				body: {
-					model: model,
+					model: the.typeModel.modelGPT,
 					messages: messages,
 				},
 			}).then(response => {
 				expect(response.status).to.eq(200, 'Status code should be 200');
-
 				expect(response.body).to.have.property('id').exist;
 				//expect(response.body.id).to.be.a('string').and.contain('-').and.exist;
 
 				expect(response.body).to.have.property('object').and.have.include('chat.completion');
-
 				expect(response.body).to.have.property('choices').and.to.be.an('array').and.to.have.lengthOf(1);
 				expect(response.body.choices[0]).to.have.property('index');
 
@@ -49,9 +46,51 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 			});
 		});
 	});
-	it.skip('2424 | Makes a successful request', () => {
+	it('2424 | Validate not create a chat completed by API with null role', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: the.url.chat,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					model: the.typeModel.modelGPT,
+					messages: [{ role: '', content: 'Hello, I want to know how to create a Test in Postman!' }],
+				},
+			}).then(response => {
+				expect(response.status).to.eq(400);
+				expect(response.body.error.message).to.contain('is not one of');
+			});
+		});
+	});
+	it('2424 | Validate not create a chat completed by API with incomplete modal name', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: the.url.chat,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					model: the.typeModel.modalInvalid,
+					messages: messages,
+				},
+			}).then(response => {
+				expect(response.status).to.eq(404);
+				expect(response.body.error.message).to.contain('does not exist');
+			});
+		});
+	});
+	it('2424 | Not making a successful request with modal Davinci-Codex does not exist', () => {
+		//Para hacer el Test de Prueba
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				failOnStatusCode: false,
 				method: 'POST',
 				url: the.url.engines_DCodex,
 				headers: {
@@ -59,12 +98,13 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 					Authorization: authorization,
 				},
 				body: {
-					model: 'gpt-3.5-turbo',
+					//model: the.typeModel.model,
+					/*NOTA: No se paso model por que ya se esta pasando en la url como (davinci-codex)*/
 					messages: [{ role: 'user', content: 'Hello!' }],
 				},
 			}).then(response => {
-				expect(response.status).to.eq(200);
-				expect(response.body).to.have.property('choices');
+				expect(response.status).to.eq(404);
+				expect(response.body.error.message).to.contain('does not exist');
 			});
 		});
 	});

--- a/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
+++ b/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
@@ -3,6 +3,7 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 	let authorization;
 	//let model;
 	let messages;
+
 	beforeEach('Precondition', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			contentType = the.headers.ContentType;
@@ -11,7 +12,7 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 			messages = the.messages;
 		});
 	});
-	it('2424 | Validate create a chat completed by API', () => {
+	it('2424 | HP | Validate create a chat completed by API', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
 				method: 'POST',
@@ -43,10 +44,11 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 				expect(response.body.usage).to.be.a('object').and.to.have.property('prompt_tokens');
 				expect(response.body.usage).to.have.property('completion_tokens');
 				expect(response.body.usage).to.have.property('total_tokens');
+				/** Expect Result: 200, Todas las validaciones incluidas en la US*/
 			});
 		});
 	});
-	it('2424 | Validate not create a chat completed by API with null role', () => {
+	it('2424 | NG | Validate not create a chat completed by API with null role', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
 				failOnStatusCode: false,
@@ -61,12 +63,13 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 					messages: [{ role: '', content: 'Hello, I want to know how to create a Test in Postman!' }],
 				},
 			}).then(response => {
-				expect(response.status).to.eq(400);
+				expect(response.status).to.eq(400, 'Status code should be 400');
 				expect(response.body.error.message).to.contain('is not one of');
+				/**Expect Result:  400, is not one of ['system', 'assistant', 'user'] - 'messages.0.role'*/
 			});
 		});
 	});
-	it('2424 | Validate not create a chat completed by API with incomplete modal name', () => {
+	it('2424 | NG | Validate not create a chat completed by API with incomplete modal name', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
 				failOnStatusCode: false,
@@ -81,12 +84,69 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 					messages: messages,
 				},
 			}).then(response => {
-				expect(response.status).to.eq(404);
+				expect(response.status).to.eq(404, 'Status code should be 404');
 				expect(response.body.error.message).to.contain('does not exist');
+				/**Expect Result:  404, The model gpt- does not exist.
+				 *
+				 * Cuando se coloca un modal incompleto o inexistente
+				 */
 			});
 		});
 	});
-	it('2424 | Not making a successful request with modal Davinci-Codex does not exist', () => {
+	it('2424 | HP | Validate create a chat completed by API with davinci modal and Prompt in body', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: the.url.completions,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					model: the.typeModel.modelDav,
+					prompt: the.prompt,
+					temperature: 0.5,
+					max_tokens: 10,
+					top_p: 1,
+					frequency_penalty: 0,
+					presence_penalty: 0,
+				},
+			}).then(response => {
+				expect(response.status).to.eq(200, 'Status code should be 200');
+				expect(response.body.choices[0]).to.have.property('text');
+				expect(response.body.choices[0].text).to.contain('\n\n');
+				/**Expect Result: 200,  Que el texto contenga \n\n*/
+			});
+		});
+	});
+	it('2424 | NG | Validate not creating an API completed chat when a Modal is not passed in the body', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: the.url.completions,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					//model: the.typeModel.modelDav,
+					prompt: the.prompt,
+					temperature: 0.5,
+					max_tokens: 10,
+					top_p: 1,
+					frequency_penalty: 0,
+					presence_penalty: 0,
+				},
+			}).then(response => {
+				expect(response.status).to.eq(400, 'Status code should be 400');
+				expect(response.body.error.message).to.contain('you must provide a model parameter');
+				/** Expect Result: 400, you must provide a model parameter*/
+			});
+		});
+	});
+	it('2424 | NG | Not making a successful request with Davinci-Codex in url and no modal', () => {
 		//Para hacer el Test de Prueba
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
@@ -99,16 +159,48 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 				},
 				body: {
 					//model: the.typeModel.model,
-					/*NOTA: No se paso model por que ya se esta pasando en la url como (davinci-codex)*/
+					/*NOTA: Solo se prueba con (davinci-codex) en la ruta e indica que no existe, sin pasar modal*/
 					messages: [{ role: 'user', content: 'Hello!' }],
 				},
 			}).then(response => {
-				expect(response.status).to.eq(404);
+				expect(response.status).to.eq(404, 'Status code should be 404');
 				expect(response.body.error.message).to.contain('does not exist');
+				/**Expect Result: 404, The model: davinci-codex does not exist
+				 *
+				 */
 			});
 		});
 	});
-	it('2424 | API test request', () => {
+	it('2424 | test test | Makes a successful request', () => {
+		//Para hacer el Test de Prueba
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: the.url.engines_DCodex,
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: authorization,
+				},
+				body: {
+					model: 'gpt-3.5-turbo',
+					messages: [{ role: 'user', content: 'Hello!' }],
+				},
+			}).then(response => {
+				//expect(response.status).to.eq(200);
+				//expect(response.body).to.have.property('choices');
+
+				/*Details: Se identifica que no da un Status 200, es como que en el enpoint no se pudiera pasar 
+			engines y model al mismo tiempo. Otra que se vio es que davinci-codex no existe ni entre los motores de la 
+			lista que se indica en la US ni en la consulta(GET) a engines, eso si hay otros con la palabra davinci.
+			Por eso se me ocurrio validarlo aparte sin model a ver que arrojaba. Revisar el test de arriba.*/
+				expect(response.status).to.eq(400, 'Status code should be 400');
+				expect(response.body.error.message).to.eql(response.body.error.message);
+				/**Expect result: 400, Error: Cannot specify both model and engine*/
+			});
+		});
+	});
+	it('2424 | test test | API test request', () => {
 		//Para hacer el Test de Prueba
 		cy.fixture('data/chatGPT.json').then(the => {
 			cy.api({
@@ -119,8 +211,12 @@ describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 					Authorization: authorization,
 				},
 			}).then(response => {
-				expect(response.status).to.eq(200);
+				expect(response.status).to.eq(200, 'Status code should be 200');
+				/*expect(response.body.data.length).to.eq(23);
+				Details: Segun la tabla indicada en el workflow del requerimiento se esperaban en la lista
+				23 model name. Actualmete se encuentran 50 algunos existente en la tabla y otros diferentes. */
 				expect(response.body.data.length).to.eq(50);
+				/*Expect result: 200, List All engine*/
 			});
 		});
 	});

--- a/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
+++ b/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
@@ -1,0 +1,30 @@
+describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
+	let contentType;
+	let authorization;
+	beforeEach('Precondition', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			contentType = the.headers.ContentType;
+			authorization = the.headers.Authorization;
+		});
+	});
+	it('2424 | API test request', () => {
+		//Para hacer el Test de Prueba
+		cy.fixture('data/chatGPT.json').then(the => {
+			/*const headers = {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${the.OpenAI_API_KEY}`,
+			};*/
+			cy.api({
+				method: 'GET',
+				url: the.url.engines,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+			}).then(response => {
+				expect(response.status).to.eq(200);
+				expect(response.body.data.length).to.eq(50);
+			});
+		});
+	});
+});

--- a/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
+++ b/cypress/e2e/Tests/How-to/API-testing/GX2-2423-OpenAI-ChatGPT.cy.js
@@ -1,19 +1,76 @@
 describe('✅OpenAI | ChatGPT | API: Create chat completion response', () => {
 	let contentType;
 	let authorization;
+	let model;
+	let messages;
 	beforeEach('Precondition', () => {
 		cy.fixture('data/chatGPT.json').then(the => {
 			contentType = the.headers.ContentType;
 			authorization = the.headers.Authorization;
+			model = the.model;
+			messages = the.messages;
+		});
+	});
+
+	it('Validate create a chat completed by API', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				method: 'POST',
+				url: the.url.chat,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					model: model,
+					messages: messages,
+				},
+			}).then(response => {
+				expect(response.status).to.eq(200, 'Status code should be 200');
+
+				expect(response.body).to.have.property('id').exist;
+				//expect(response.body.id).to.be.a('string').and.contain('-').and.exist;
+
+				expect(response.body).to.have.property('object').and.have.include('chat.completion');
+
+				expect(response.body).to.have.property('choices').and.to.be.an('array').and.to.have.lengthOf(1);
+				expect(response.body.choices[0]).to.have.property('index');
+
+				expect(response.body.choices[0].message).to.have.property('content');
+				expect(response.body.choices[0].message).to.have.property('role');
+
+				//expect(response.body.choices[0].message).to.have.property('role').to.include('assistant');
+				//expect(response.body.choices[0].message).to.have.property('role').and.to.have.property('content');
+				expect(response.body.choices[0]).to.have.property('finish_reason');
+
+				expect(response.body.usage).to.be.a('object').and.to.have.property('prompt_tokens');
+				expect(response.body.usage).to.have.property('completion_tokens');
+				expect(response.body.usage).to.have.property('total_tokens');
+			});
+		});
+	});
+	it.skip('2424 | Makes a successful request', () => {
+		cy.fixture('data/chatGPT.json').then(the => {
+			cy.api({
+				method: 'POST',
+				url: the.url.engines_DCodex,
+				headers: {
+					'Content-Type': contentType,
+					Authorization: authorization,
+				},
+				body: {
+					model: 'gpt-3.5-turbo',
+					messages: [{ role: 'user', content: 'Hello!' }],
+				},
+			}).then(response => {
+				expect(response.status).to.eq(200);
+				expect(response.body).to.have.property('choices');
+			});
 		});
 	});
 	it('2424 | API test request', () => {
 		//Para hacer el Test de Prueba
 		cy.fixture('data/chatGPT.json').then(the => {
-			/*const headers = {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${the.OpenAI_API_KEY}`,
-			};*/
 			cy.api({
 				method: 'GET',
 				url: the.url.engines,

--- a/cypress/fixtures/data/chatGPT.json
+++ b/cypress/fixtures/data/chatGPT.json
@@ -1,11 +1,14 @@
 {
 	"url": {
 		"engines": "https://api.openai.com/v1/engines",
+		"engines_DCodex": "https://api.openai.com/v1/engines/davinci-codex/completions",
 		"chat": "https://api.openai.com/v1/chat/completions"
 	},
+	"model": "gpt-3.5-turbo",
+	"messages": [{ "role": "user", "content": "Hello, I want to know how to create a Test in Postman!" }],
 	"headers": {
 		"ContentType": "application/json",
 		"Authorization": "Bearer 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"
 	},
-	"OpenAI_API_KEY": "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"
+	"openAI_API_KEY": "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"
 }

--- a/cypress/fixtures/data/chatGPT.json
+++ b/cypress/fixtures/data/chatGPT.json
@@ -1,0 +1,11 @@
+{
+	"url": {
+		"engines": "https://api.openai.com/v1/engines",
+		"chat": "https://api.openai.com/v1/chat/completions"
+	},
+	"headers": {
+		"ContentType": "application/json",
+		"Authorization": "Bearer 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"
+	},
+	"OpenAI_API_KEY": "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"
+}

--- a/cypress/fixtures/data/chatGPT.json
+++ b/cypress/fixtures/data/chatGPT.json
@@ -4,7 +4,11 @@
 		"engines_DCodex": "https://api.openai.com/v1/engines/davinci-codex/completions",
 		"chat": "https://api.openai.com/v1/chat/completions"
 	},
-	"model": "gpt-3.5-turbo",
+	"typeModel": {
+		"modelGPT": "gpt-3.5-turbo",
+		"modelDav": "davinci",
+		"modalInvalid": "gpt-"
+	},
 	"messages": [{ "role": "user", "content": "Hello, I want to know how to create a Test in Postman!" }],
 	"headers": {
 		"ContentType": "application/json",

--- a/cypress/fixtures/data/chatGPT.json
+++ b/cypress/fixtures/data/chatGPT.json
@@ -2,14 +2,16 @@
 	"url": {
 		"engines": "https://api.openai.com/v1/engines",
 		"engines_DCodex": "https://api.openai.com/v1/engines/davinci-codex/completions",
-		"chat": "https://api.openai.com/v1/chat/completions"
+		"chat": "https://api.openai.com/v1/chat/completions",
+		"completions": "https://api.openai.com/v1/completions"
 	},
 	"typeModel": {
 		"modelGPT": "gpt-3.5-turbo",
 		"modelDav": "davinci",
 		"modalInvalid": "gpt-"
 	},
-	"messages": [{ "role": "user", "content": "Hello, I want to know how to create a Test in Postman!" }],
+	"prompt": "Hello, why are you OpenAI?",
+	"messages": [{ "role": "user", "content": "Hello, I want to know how to create a Test in Cypress!" }],
 	"headers": {
 		"ContentType": "application/json",
 		"Authorization": "Bearer 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"


### PR DESCRIPTION
**Buenas Tardes Team:** 
**ALL TEST PASSED**
Se considero para las pruebas hacer uso del fixtures para pasar las url, typeModel(segun el modelo), prompt, message, y el headers, descrita como valida en el readme. A continuaciones mas detalles de cada uno de los tests realizados: 

**NOTA:** Los dos ultimos tests fueron plateados en la US de pruebas para validar que se comportara como deberia una vez generado el bearer token la cual se comprueba la seguridad de las credenciales y con esta se utiliza para todos los demas, para luego hacer el que corresponde al AC que observe tienen diferentes enpoint e igual los detalles por cada uno a continuación: 
 
**2424 | HP | Validate create a chat completed by API**
Details: Se validan las assetion requeridas en el AC. Actualmente son las esperadas. 

2424 | NG | Validate not create a chat completed by API with null role
Details: En la url https://api.openai.com/v1/chat/completions se valida que se debe colocar al menos un Role, cuando esta propiedad se deje vacia.  

**2424 | NG | Validate not create a chat completed by API with incomplete modal name**
Details: En la url https://api.openai.com/v1/chat/completions se valida que con un model invalido(ya sea incompleto o inexistente) retorne un mensaje que no existe. 

2424 | HP | Validate create a chat completed by API with davinci modal and Prompt in body
Details: Se valida con el model Davinci se pueda pasar un prompt y en el response se obtenga la propiedad "text" y que el mismo inicie en "\n\n" la cual retorna una respuesta segun el prompt.

**2424 | NG | Validate not creating an API completed chat when a Modal is not passed in the body**
Details: En la url https://api.openai.com/v1/completions en el body no pasamos un model para probar que exiga el model.

**2424 | NG | Not making a successful request with Davinci-Codex in url and no modal**
Details: Con el url https://api.openai.com/v1/engines/davinci-codex/completions se esta pasando davinci-codex, y se valida segun la tabla de compatibilidad ese model no existe, como se esta pasando en la ruta no lo pasamos en el body para probar. 

Los dos ultimos tests son los propuesto en la US como pruebas, a continuación: 

**2424 | test test | Makes a successful request**
Details: Se identifica que no da un Status 200, es como que en el enpoint no se pudiera pasar engines y model al mismo tiempo. Otra que se vio es que davinci-codex no existe ni entre los motores de la lista que se indica en la US ni en la consulta(GET) a engines, eso si hay otros con la palabra davinci. Por eso se me ocurrio validarlo aparte sin model a ver que arrojaba. Revisar el test de arriba.

**2424 | test test | API test request**
Detail: Details: Segun la tabla indicada en el workflow del requerimiento se esperaban en la lista 23 model name. Actualmete se encuentran 50 algunos existente en la tabla y otros diferentes. 

A continuación se indica los que actualmente no estan en el response, como valor agregado: 
Enpoint: /v1/chat/completions
Existentes los descripto exepto: gpt-4, gpt-4-0314, gpt-4-32k, gpt-4-32k-0314. 

Enpoint: /v1/fine-tunes 
Existen los descritos exepto "curie"

/v1/moderations
No existen los descritos

Para los siguientes enpoints existen los descritos: 
/v1/completions
/v1/edits
/v1/audio/transcriptionsEnpoint /v1/audio/transcriptions
/v1/embedding

Espero de su revisión! Gracias. 
**QA Analyst Manual/Automation: Lilibeth Camico** 🙂 